### PR TITLE
Add CRUD tests for password manager

### DIFF
--- a/test/password_manager_tests.cpp
+++ b/test/password_manager_tests.cpp
@@ -21,6 +21,30 @@ auto MakeTemporaryVault(std::string const& prefix = "vault_test_") -> fs::path {
 
 TEST_CASE("Authorize generates salt+nonce and derives a master key",
           "[Authorize]") {
+  auto const vault = MakeTemporaryVault();
+  auto const password = std::string{"test_password"};
+
+  auto const ctx = pm::Authorize(password, vault.string());
+
+  REQUIRE(ctx.vault_path == vault.string());
+  REQUIRE(std::ranges::any_of(ctx.salt, [](std::byte b) { return b != std::byte{}; }));
+  REQUIRE(std::ranges::any_of(ctx.nonce, [](std::byte b) { return b != std::byte{}; }));
+  REQUIRE(std::ranges::any_of(ctx.master_key, [](std::byte b) { return b != std::byte{}; }));
+}
+
+TEST_CASE("PasswordsStore basic CRUD", "[PasswordsStore]") {
+  auto const vault = MakeTemporaryVault();
+  auto const ctx = pm::Authorize("pw", vault.string());
+  pm::PasswordsStore store{ctx};
+
+  auto const key = std::string{"key1"};
+  auto const value = std::string{"value1"};
+
+  store.Add(key, value);
+  REQUIRE(store.Get(key) == value);
+
+  store.Delete(key);
+  REQUIRE_THROWS_AS(store.Get(key), std::out_of_range);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- expand test suite
- verify Authorize generates components
- add CRUD coverage for PasswordsStore

## Testing
- `clang++ -std=c++20 test/password_manager_tests.cpp -o test_binary` *(fails: 'catch2/catch_all.hpp' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840455436c883279f570a00c39059d6