### PR TITLE
docs: update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The `upm` binary will be produced in `build/` just like a local build.
 
 ### cmake
 
-Should be fairly straightforward to use `clang++` (>v20) or `cmake` (>v4) to build the project. The 
-source are provided:
+Should be fairly straightforward to use `clang++` (>v20) or `cmake` (>v4) to build the project. The
+source files are provided:
 - `password_manager.cppm`
 - `main.cpp`
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A simple, secure command-line password manager built with modern C++.
 
+The tool stores credentials in an encrypted JSON file and showcases the use of
+C++20 modules alongside the libsodium crypto library. It is intentionally small
+to keep the build and usage simple while still being practical.
+
 ## Overview
 
 This application provides a straightforward way to store, retrieve, and manage passwords from the command line.
@@ -27,6 +31,31 @@ $ ninja -f build/build.ninja
 ```
 
 The built tool can be found as `build/upm`
+
+### Docker based build
+
+The CI workflow builds the tool inside Docker containers using
+`docker buildx` (see `.github/workflows/main.yml`).  The same steps can be run
+locally:
+
+```bash
+# build the base image with the modules toolchain
+docker buildx build \
+  -f dockers/cpp-modules-base/cpp_modules_base.dockerfile \
+  -t cpp-modules-base .
+
+# build the final image containing the application
+docker buildx build \
+  -f dockers/password-manager.dockerfile \
+  --load -t upm-final .
+
+# run the build and tests inside the container
+docker run --rm -v $(pwd):/work -w /work upm-final \
+  bash -c "cd test && modi && ninja -f build/build.ninja && ./build/upm_tests"
+```
+
+This produces the `upm` binary in the `build/` directory just like the manual
+build.
 
 ### cmake
 

--- a/README.md
+++ b/README.md
@@ -20,23 +20,21 @@ This application provides a straightforward way to store, retrieve, and manage p
 
 ## Build
 
-### in-house build flow
+You can compile the project locally or inside the same Docker setup used by the
+CI workflow (see `.github/workflows/main.yml`).  Both approaches rely on the
+[modi](https://github.com/uzleosharif/module-builder) tool to generate the
+`build.ninja` file.
 
-Use [modi](https://github.com/uzleosharif/module-builder) tool.
+### Local build
 
-```
+```bash
 $ git clone <this repo>
-$ modi
-$ ninja -f build/build.ninja
+$ modi && ninja -f build/build.ninja
 ```
 
-The built tool can be found as `build/upm`
+The resulting `upm` binary will appear in `build/upm`.
 
-### Docker based build
-
-The CI workflow builds the tool inside Docker containers using
-`docker buildx` (see `.github/workflows/main.yml`).  The same steps can be run
-locally:
+### Docker build
 
 ```bash
 # build the base image with the modules toolchain
@@ -49,13 +47,12 @@ docker buildx build \
   -f dockers/password-manager.dockerfile \
   --load -t upm-final .
 
-# run the build and tests inside the container
+# run the build inside the container
 docker run --rm -v $(pwd):/work -w /work upm-final \
-  bash -c "cd test && modi && ninja -f build/build.ninja && ./build/upm_tests"
+  bash -c "modi && ninja -f build/build.ninja"
 ```
 
-This produces the `upm` binary in the `build/` directory just like the manual
-build.
+The `upm` binary will be produced in `build/` just like a local build.
 
 ### cmake
 


### PR DESCRIPTION
## Summary
- expand project description
- document Docker-based build procedure

## Testing
- `modi && ninja -f build/build.ninja && ./build/upm_tests` *(fails: `bash: modi: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840b3981a18832798b368c2d655a99d