### PR TITLE
Add libsodium initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,16 @@ build build/upm: link build/main.o build/password_manager.o
 
 Before running the tool, set the environment-variable `UPM_PASSWORDS_FILE_PATH` 
 to point to the location of encrypted vault file on disk.
+
 For example, `export UPM_PASSWORDS_FILE_PATH="/home/user/.upm/vault.bin"`.
+
+### Libsodium Initialization
+
+The program uses the libsodium library for all cryptographic operations.
+`pm::PasswordsStore` initializes libsodium when it is first constructed and
+throws a `std::runtime_error` if initialization fails. If you reuse the code,
+make sure that a `PasswordsStore` instance is successfully created before using
+other libsodium APIs.
 
 The password manager is used through command-line arguments:
 
@@ -161,4 +170,3 @@ If you forget the master password, the vault can not be decrypted.
 ## License
 
 This project is licensed under the MIT License.
-

--- a/src/password_manager.cppm
+++ b/src/password_manager.cppm
@@ -90,6 +90,10 @@ auto LoadOrGenerateSaltAndNonce(std::string_view vault_path, salt_t& salt,
 
 export namespace pm {
 
+inline bool g_libsodium_initialized{false};
+
+[[nodiscard]] auto IsLibsodiumInitialized() -> bool { return g_libsodium_initialized; }
+
 struct Context {
   std::string_view vault_path;
   salt_t salt;
@@ -127,6 +131,12 @@ class PasswordsStore final {
  public:
   constexpr explicit PasswordsStore(Context const& context)
       : m_context{context} {
+    if (!g_libsodium_initialized) {
+      if (sodium_init() < 0) {
+        throw std::runtime_error{"libsodium initialization failed"};
+      }
+      g_libsodium_initialized = true;
+    }
     if (std::filesystem::exists(m_context.vault_path)) {
       auto plain_text{LoadAndDecrypt()};
       m_passwords = uzleo::json::Parse(std::string_view{

--- a/test/password_manager_tests.cpp
+++ b/test/password_manager_tests.cpp
@@ -23,6 +23,25 @@ auto const HasNonZero = [](auto const& buffer) {
   });
 };
 
+TEST_CASE("libsodium is initialized before cryptography functions are used",
+          "[Init]") {
+  auto vault_path_string = MakeTemporaryVault().string();
+
+  auto context = pm::Authorize("master", vault_path_string);
+  REQUIRE(context.vault_path == vault_path_string);
+
+  REQUIRE(sodium_init() == 1);
+}
+
+TEST_CASE("PasswordsStore initializes libsodium", "[Init]") {
+  auto vault_path_string = MakeTemporaryVault().string();
+
+  auto context = pm::Authorize("master", vault_path_string);
+  pm::PasswordsStore store(context);
+
+  REQUIRE(pm::IsLibsodiumInitialized());
+}
+
 }  // namespace
 
 TEST_CASE("Authorize generates salt+nonce and derives a master key",


### PR DESCRIPTION
## Summary
- check libsodium initialization in tests
- initialize libsodium when constructing `PasswordsStore`
- document libsodium initialization requirements

## Testing
- `cd test && modi && ninja -f build/build.ninja && ./build/upm_tests` *(fails: `modi: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68416f6f56b8832793f62787447ca2ec