### PR TITLE
Use mock crypto for tests

### DIFF
--- a/test/build.json
+++ b/test/build.json
@@ -4,11 +4,10 @@
 {
   "src": {
     "../src/utils.cppm": [],
-    "../src/crypto.cppm": [],
     "../src/password_manager.cppm": ["../src/utils.cppm"],
-    "password_manager_tests.cpp": ["../src/password_manager.cppm", "../src/crypto.cppm"]
+    "password_manager_tests.cpp": ["../src/password_manager.cppm"]
   },
   "imp": ["std", "uzleo.json", "fmt"],
-  "l": ["sodium", "Catch2Main", "Catch2"],
+  "l": ["Catch2Main", "Catch2"],
   "e": "upm_tests"
 }

--- a/test/password_manager_tests.cpp
+++ b/test/password_manager_tests.cpp
@@ -2,14 +2,15 @@
 #include <catch2/catch_all.hpp>
 
 import password_manager;
-import crypto;
+import utils;
 import std;
-import fmt;
 
 namespace fs = std::filesystem;
 namespace chr = std::chrono;
 
 namespace {
+
+namespace utils = ::uzleo::utils;
 
 auto MakeTemporaryVault(std::string const& prefix = "vault_test_") -> fs::path {
   return fs::temp_directory_path() /
@@ -18,10 +19,62 @@ auto MakeTemporaryVault(std::string const& prefix = "vault_test_") -> fs::path {
               chr::high_resolution_clock::now().time_since_epoch().count()));
 }
 
-auto const HasNonZero = [](auto const& buffer) {
-  return std::any_of(buffer.begin(), buffer.end(), [](std::byte byte_val) {
-    return byte_val != std::byte{0};
-  });
+class MockCrypto final {
+ public:
+  static constexpr std::size_t kSaltSize{1};
+  static constexpr std::size_t kNonceSize{1};
+  static constexpr std::size_t kVaultSize{kSaltSize + kNonceSize + 1};
+  static constexpr std::size_t kMasterKeySize{1};
+
+  MockCrypto() = default;
+  MockCrypto(utils::StaticByteBuffer<kSaltSize> const& salt,
+             utils::StaticByteBuffer<kNonceSize> const& nonce)
+      : m_salt{salt}, m_nonce{nonce} {
+  }
+
+  void Authorize(std::string_view master_password) {
+    m_key = static_cast<std::byte>(master_password.size() % 256);
+  }
+
+  [[nodiscard]] auto Decrypt(utils::DynamicByteBuffer const& cipher_text) const
+      -> utils::DynamicByteBuffer {
+    auto len = static_cast<std::size_t>(
+        std::to_integer<unsigned char>(cipher_text[0]));
+    utils::DynamicByteBuffer plain;
+    plain.resize(len);
+    for (std::size_t i = 0; i < len; ++i) {
+      plain[i] = static_cast<std::byte>(
+          std::to_integer<unsigned char>(cipher_text[i + 1]) ^
+          std::to_integer<unsigned char>(m_key));
+    }
+    return plain;
+  }
+
+  [[nodiscard]] auto Encrypt(std::string_view plain_text)
+      -> utils::DynamicByteBuffer {
+    utils::DynamicByteBuffer cipher;
+    cipher.resize(plain_text.size() + 1);
+    cipher[0] = static_cast<std::byte>(plain_text.size());
+    for (std::size_t i = 0; i < plain_text.size(); ++i) {
+      cipher[i + 1] =
+          static_cast<std::byte>(static_cast<unsigned char>(plain_text[i]) ^
+                                 std::to_integer<unsigned char>(m_key));
+    }
+    return cipher;
+  }
+
+  [[nodiscard]] auto GetSalt() const -> std::span<std::byte const> {
+    return m_salt;
+  }
+
+  [[nodiscard]] auto GetNonce() const -> std::span<std::byte const> {
+    return m_nonce;
+  }
+
+ private:
+  utils::StaticByteBuffer<kSaltSize> m_salt{};
+  utils::StaticByteBuffer<kNonceSize> m_nonce{};
+  std::byte m_key{std::byte{0}};
 };
 
 }  // namespace
@@ -35,7 +88,7 @@ TEST_CASE("PasswordsStore persists added and deleted passwords",
   std::uintmax_t size_after_delete = 0;
 
   {
-    pm::PasswordsStore<pm::SodiumCrypto> store(master, vault_path_string);
+    pm::PasswordsStore<MockCrypto> store(master, vault_path_string);
 
     REQUIRE(fs::exists(vault_path_string));
     REQUIRE(store.Get("foo") == "bar");
@@ -52,7 +105,7 @@ TEST_CASE("PasswordsStore persists added and deleted passwords",
     REQUIRE_THROWS_AS(store.Get("foo"), std::out_of_range);
   }
 
-  pm::PasswordsStore<pm::SodiumCrypto> store2(master, vault_path_string);
+  pm::PasswordsStore<MockCrypto> store2(master, vault_path_string);
   REQUIRE(store2.Get("alpha") == "beta");
   REQUIRE_THROWS_AS(store2.Get("foo"), std::out_of_range);
   REQUIRE(fs::file_size(vault_path_string) == size_after_delete);


### PR DESCRIPTION
## Summary
- replace SodiumCrypto with a simple mock in password manager tests
- adjust test build script to drop libsodium dependency

------
https://chatgpt.com/codex/tasks/task_e_6843eae1d4d08327b59e0127dcdee288