### PR TITLE
Add change master password feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ upm delete <key>
 
 Removes the password entry associated with the specified key.
 
+#### Change the master password
+
+```bash
+upm change <new-master-password>
+```
+
+Re-encrypts the entire vault using the new master password. After running this
+command, the old password can no longer decrypt the vault.
+
 ### Flow
 
 On first usage, the tool will prompt for a master password. It derives a

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@ auto ShowUsage() {
   fmt::println(" get <key>");
   fmt::println(" list");
   fmt::println(" delete <key>");
+  fmt::println(" change <new-master-password>");
 
   throw std::invalid_argument{"Incorrect usage."};
 }
@@ -80,6 +81,8 @@ auto ProcessInput(auto args_view) {
     password_store.List();
   } else if (command == "delete" and rng::size(args_view) == 3) {
     password_store.Delete(args_view[2]);
+  } else if (command == "change" and rng::size(args_view) == 3) {
+    password_store.ChangeMasterPassword(args_view[2]);
   } else {
     ShowUsage();
   }

--- a/src/password_manager.cppm
+++ b/src/password_manager.cppm
@@ -99,6 +99,14 @@ class PasswordsStore final {
     SaveVault(m_crypto_library->Encrypt(fmt::format("{}", m_passwords)));
   }
 
+  constexpr auto ChangeMasterPassword(std::string_view new_password) -> void {
+    auto new_crypto = std::make_unique<CryptoLibrary>();
+    new_crypto->Authorize(new_password);
+
+    m_crypto_library = std::move(new_crypto);
+    SaveVault(m_crypto_library->Encrypt(fmt::format("{}", m_passwords)));
+  }
+
  private:
   [[nodiscard]] constexpr auto LoadVault() const
       -> std::tuple<salt_t, nonce_t, utils::DynamicByteBuffer> {

--- a/test/password_manager_tests.cpp
+++ b/test/password_manager_tests.cpp
@@ -111,3 +111,18 @@ TEST_CASE("PasswordsStore persists added and deleted passwords",
   REQUIRE_THROWS_AS(store2.Get("alpha"), std::out_of_range);
   REQUIRE(fs::file_size(vault_path_string) == size_after_delete);
 }
+
+TEST_CASE("PasswordsStore can change master password", "[PasswordsStore]") {
+  auto vault_path_string = MakeTemporaryVault("vault_change_").string();
+
+  {
+    pm::PasswordsStore<MockCrypto> store{"oldpass", vault_path_string};
+    store.Add("key", "value");
+    store.ChangeMasterPassword("newpassword");
+  }
+
+  REQUIRE_THROWS(pm::PasswordsStore<MockCrypto>{"oldpass", vault_path_string});
+
+  pm::PasswordsStore<MockCrypto> reopened{"newpassword", vault_path_string};
+  REQUIRE(reopened.Get("key") == "value");
+}


### PR DESCRIPTION
## Summary
- add CLI command `change` for updating the master password
- implement `ChangeMasterPassword` in `PasswordsStore`
- document the command in README
- test the new behavior with `MockCrypto`



------
https://chatgpt.com/codex/tasks/task_e_684acd99a5e08327b169b48ea11477ab