### PR TITLE
Remove default entry from new vaults

### DIFF
--- a/src/password_manager.cppm
+++ b/src/password_manager.cppm
@@ -46,7 +46,7 @@ class PasswordsStore final {
     } else {
       m_crypto_library = std::make_unique<CryptoLibrary>();
       m_crypto_library->Authorize(master_password);
-      Add("foo", "bar");
+      SaveVault(m_crypto_library->Encrypt(fmt::format("{}", m_passwords)));
     }
   }
 

--- a/test/password_manager_tests.cpp
+++ b/test/password_manager_tests.cpp
@@ -91,7 +91,7 @@ TEST_CASE("PasswordsStore persists added and deleted passwords",
     pm::PasswordsStore<MockCrypto> store(master, vault_path_string);
 
     REQUIRE(fs::exists(vault_path_string));
-    REQUIRE_THROWS_AS(store.Get("baz"), std::out_of_range);
+    REQUIRE_THROWS_AS(store.Get("foo"), std::out_of_range);
 
     auto size_initial = fs::file_size(vault_path_string);
     store.Add("alpha", "beta");


### PR DESCRIPTION
## Summary
- don't create a `foo/bar` record when initializing a new vault
- update tests to confirm vaults start empty

------
https://chatgpt.com/codex/tasks/task_e_684ad26d929c83278ab2a4538c5e0d00