### PR TITLE
Implement password generator command

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ upm delete <key>
 
 Removes the password entry associated with the specified key.
 
+#### Generate and store a password
+
+```bash
+upm generate <key> [length] [charset]
+```
+
+Creates a random password using libsodium's RNG and stores it under the
+specified key. The optional `length` argument controls password length (default
+16) and `charset` provides the allowed characters. If no charset is supplied, a
+mix of alphanumeric characters is used.
+
 ### Flow
 
 On first usage, the tool will prompt for a master password. It derives a

--- a/build.json
+++ b/build.json
@@ -1,6 +1,6 @@
 
 {
-  "src": ["src/utils.cppm", "src/password_manager.cppm", "src/main.cpp", "src/crypto.cppm"],
+  "src": ["src/utils.cppm", "src/password_manager.cppm", "src/password_generator.cppm", "src/main.cpp", "src/crypto.cppm"],
   "imp": ["std", "uzleo.json", "fmt"],
   "l": ["sodium"],
   "e": "upm"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import password_manager;
+import password_generator;
 import std;
 import fmt;
 import crypto;
@@ -19,6 +20,7 @@ auto ShowUsage() {
   fmt::println(" get <key>");
   fmt::println(" list");
   fmt::println(" delete <key>");
+  fmt::println(" generate <key> [length] [charset]");
 
   throw std::invalid_argument{"Incorrect usage."};
 }
@@ -80,6 +82,22 @@ auto ProcessInput(auto args_view) {
     password_store.List();
   } else if (command == "delete" and rng::size(args_view) == 3) {
     password_store.Delete(args_view[2]);
+  } else if (command == "generate" and
+             (rng::size(args_view) == 3 || rng::size(args_view) == 4 ||
+              rng::size(args_view) == 5)) {
+    std::size_t length = 0;
+    std::string_view charset = pm::kDefaultCharset;
+    if (rng::size(args_view) >= 4) {
+      length = std::stoull(std::string{args_view[3]});
+    } else {
+      length = pm::kDefaultLength;
+    }
+    if (rng::size(args_view) == 5) {
+      charset = args_view[4];
+    }
+    auto password = pm::GeneratePassword(length, charset);
+    password_store.Add(args_view[2], password);
+    fmt::println("{}", password);
   } else {
     ShowUsage();
   }

--- a/src/password_generator.cppm
+++ b/src/password_generator.cppm
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+
+module;
+
+#include <sodium.h>
+
+export module password_generator;
+
+import std;
+
+namespace rng = std::ranges;
+
+export namespace pm {
+
+inline constexpr std::string_view kDefaultCharset{
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"};
+
+inline constexpr std::size_t kDefaultLength{16};
+
+inline auto GeneratePassword(std::size_t length = kDefaultLength,
+                             std::string_view charset = kDefaultCharset)
+    -> std::string {
+  if (charset.empty()) {
+    throw std::invalid_argument{"charset cannot be empty"};
+  }
+
+  if (sodium_init() < 0) {
+    throw std::runtime_error{"sodium_init failed"};
+  }
+
+  std::string password;
+  password.resize(length);
+
+  for (std::size_t i = 0; i < length; ++i) {
+    unsigned char byte{};
+    randombytes_buf(&byte, 1);
+    password[i] = charset[byte % charset.size()];
+  }
+
+  return password;
+}
+
+} // namespace pm
+

--- a/test/build.json
+++ b/test/build.json
@@ -4,6 +4,7 @@
   "src": [
     "../src/utils.cppm",
     "../src/password_manager.cppm",
+    "../src/password_generator.cppm",
     "../src/crypto.cppm",
     "password_manager_tests.cpp",
     "sodium_crypto_tests.cpp"

--- a/test/password_manager_tests.cpp
+++ b/test/password_manager_tests.cpp
@@ -2,6 +2,7 @@
 #include <catch2/catch_all.hpp>
 
 import password_manager;
+import password_generator;
 import utils;
 import std;
 
@@ -110,4 +111,21 @@ TEST_CASE("PasswordsStore persists added and deleted passwords",
   pm::PasswordsStore<MockCrypto> store2(master, vault_path_string);
   REQUIRE_THROWS_AS(store2.Get("alpha"), std::out_of_range);
   REQUIRE(fs::file_size(vault_path_string) == size_after_delete);
+}
+
+TEST_CASE("Generated passwords follow length and charset", "[PasswordGenerator]") {
+  constexpr std::string_view charset{"abc123"};
+  auto pass = pm::GeneratePassword(32, charset);
+  REQUIRE(pass.size() == 32);
+  REQUIRE(std::ranges::all_of(pass, [](char c) { return charset.find(c) != std::string_view::npos; }));
+}
+
+TEST_CASE("PasswordsStore stores generated password", "[PasswordGenerator][PasswordsStore]") {
+  auto vault_path_string = MakeTemporaryVault("vault_gen_").string();
+  pm::PasswordsStore<MockCrypto> store("master", vault_path_string);
+
+  auto generated = pm::GeneratePassword();
+  store.Add("gen", generated);
+
+  REQUIRE(store.Get("gen") == generated);
 }


### PR DESCRIPTION
## Summary
- support random password generation via libsodium
- store generated passwords using new CLI command
- expose helper module `password_generator`
- document generation feature
- test password generation

## Testing
- `modi` *(fails: command not found)*
- `ninja -f build/build.ninja` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684ad2855ef883279078674dd1150604